### PR TITLE
Add an option to make the installation of ssmtp optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/geerlingguy/ansible-role-mailhog.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-mailhog)
 
-Installs [MailHog](https://github.com/ian-kent/Go-MailHog), a Go-based SMTP server and web UI/API for displaying captured emails, on RedHat or Debian-based linux systems. Also installs sSMTP so you can easily redirect local email to the SMTP server.
+Installs [MailHog](https://github.com/ian-kent/Go-MailHog), a Go-based SMTP server and web UI/API for displaying captured emails, on RedHat or Debian-based linux systems.
 
 Also installs sSMTP so you can redirect system mail to MailHog's built-in SMTP server.
 
@@ -26,13 +26,14 @@ The MailHog binary that will be installed. You can find the latest version or a 
 
 The directory into which the MailHog binary will be installed.
 
+    ssmtp_install: yes
     ssmtp_mailhub: localhost:1025
     ssmtp_root: postmaster
     ssmtp_authuser: ""
     ssmtp_authpass: ""
     ssmtp_from_line_override: "YES"
 
-sSMTP options. These should work with MailHog's default configuration.
+sSMTP options. These should work with MailHog's default configuration. Note that this will replace an already existing sendmail binary, set ssmtp_install to `no`to not install it.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.1.6/MailHog_linux_amd64
 mailhog_install_dir: /opt/mailhog
 
+ssmtp_install: yes
 ssmtp_mailhub: localhost:1025
 ssmtp_root: postmaster
 ssmtp_authuser: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,10 +29,10 @@
 
 # Install and configure sSMTP.
 - include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ssmtp_install
 
 - include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and ssmtp_install
 
 - name: Copy sSMTP configuration.
   template:
@@ -41,3 +41,4 @@
     owner: root
     group: root
     mode: 0644
+  when: ssmtp_install


### PR DESCRIPTION
I want to use mailhog but not replace the default sendmail on my systems, so I added an option to skip those steps.

Also removed a duplicated line from the readme.
