### PR TITLE
Add support for RedHat Linux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version.split(".")[0]|int >= 16) or
     (ansible_distribution == 'Debian' and ansible_distribution_version.split(".")[0]|int >= 8) or
     (ansible_distribution == 'CentOS' and ansible_distribution_version.split(".")[0]|int >= 7) or
+    (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0]|int >= 7) or
     (ansible_distribution == 'Fedora')
 
 - name: Ensure mailhog is enabled and will start on boot.


### PR DESCRIPTION
We're using the mailhog role but noticed that it fails on RedHat due to a lack of specific reference in the systemd task.