### PR TITLE
Feature/overriding templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ The path to `daemonize`, which is used to launch MailHog via init script.
 
 The mhsendmail binary that will be installed. You can find the latest version or a 32-bit version by visiting the [mhsendmail project releases page](https://github.com/mailhog/mhsendmail/releases).
 
+## Overriding templates
+
+If you want to configure MailHog using one of the [MailHog Configuration options](https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md) which 
+you can't customize via variables because an option isn't exposed, you can override the template used to start MailHog.
+
+```yaml
+mailhog_init_template: mailhog.init.j2
+mailhog_unit_template: mailhog.unit.j2
+```
+
+You can either copy and modify the provided template, or extend it with [Jinja2 template inheritance](http://jinja.pocoo.org/docs/2.9/templates/#template-inheritance) and override the specific template block you need to change.
+
 ## Dependencies
 
   - geerlingguy.daemonize

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ mhsendmail_binary_url: https://github.com/mailhog/mhsendmail/releases/download/v
 
 # Path to daemonize, which is used to launch MailHog via init script.
 mailhog_daemonize_bin_path: /usr/sbin/daemonize
+
+mailhog_init_template: mailhog.init.j2
+mailhog_unit_template: mailhog.unit.j2

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: systemd daemon reload
+  command: systemctl daemon-reload
+- name: restart mailhog
+  service:
+    name=mailhog
+    state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,21 +23,25 @@
 
 - name: Copy mailhog init script into place.
   template:
-    src: mailhog.init.j2
+    src: "{{ mailhog_init_template }}"
     dest: /etc/init.d/mailhog
     owner: root
     group: root
     mode: 0755
   when: "ansible_service_mgr != 'systemd'"
+  notify: restart mailhog
 
 - name: Copy mailhog systemd unit file into place (for systemd systems).
   template:
-    src: mailhog.unit.j2
+    src: "{{ mailhog_unit_template }}"
     dest: /etc/systemd/system/mailhog.service
     owner: root
     group: root
     mode: 0755
   when: "ansible_service_mgr == 'systemd'"
+  notify:
+    - systemd daemon reload
+    - restart mailhog
 
 - name: Ensure mailhog is enabled and will start on boot.
   service: name=mailhog state=started enabled=yes


### PR DESCRIPTION
This allows us to start MailHog using options not suppored with variables in this module. For example to bind MailHog on 127.0.0.1.
This pull request addresses https://github.com/geerlingguy/ansible-role-mailhog/issues/18 as well