### PR TITLE
Feature/specify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The path to `daemonize`, which is used to launch MailHog via init script.
 
     mhsendmail_version: 0.2.0
     
-The version of the mhsendmail binary that will installed. You can find the latet version by visiting the [mhsendmail project releases page](https://github.com/mailhog/mhsendmail/releases).
+The version of the mhsendmail binary that will be installed. You can find the latest version by visiting the [mhsendmail project releases page](https://github.com/mailhog/mhsendmail/releases).
 
     mhsendmail_binary_url: "https://github.com/mailhog/mhsendmail/releases/download/v{{ mhsendmail_version }}/mhsendmail_linux_amd64"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The directory into which the MailHog binary will be installed.
 
-    mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.2.1/MailHog_linux_amd64
+    mailhog_version: 0.2.1
+
+The version of MailHog that will be installed. You can find the latest version by visiting the [MailHog project releases page](https://github.com/mailhog/MailHog/releases).
+
+    mailhog_binary_url: "https://github.com/mailhog/MailHog/releases/download/v{{ mailhog_version }}/MailHog_linux_amd64"
 
 The MailHog binary that will be installed. You can find the latest version or a 32-bit version by visiting the [MailHog project releases page](https://github.com/mailhog/MailHog/releases).
 
@@ -32,7 +36,11 @@ The MailHog binary that will be installed. You can find the latest version or a 
 
 The path to `daemonize`, which is used to launch MailHog via init script.
 
-    mhsendmail_binary_url: https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64
+    mhsendmail_version: 0.2.0
+    
+The version of the mhsendmail binary that will installed. You can find the latet version by visiting the [mhsendmail project releases page](https://github.com/mailhog/mhsendmail/releases).
+
+    mhsendmail_binary_url: "https://github.com/mailhog/mhsendmail/releases/download/v{{ mhsendmail_version }}/mhsendmail_linux_amd64"
 
 The mhsendmail binary that will be installed. You can find the latest version or a 32-bit version by visiting the [mhsendmail project releases page](https://github.com/mailhog/mhsendmail/releases).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 mailhog_install_dir: /opt/mailhog
-mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.2.1/MailHog_linux_amd64
-mhsendmail_binary_url: https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64
+mailhog_version: 0.2.1
+mailhog_binary_url: "https://github.com/mailhog/MailHog/releases/download/v{{ mailhog_version }}/MailHog_linux_amd64"
+mhsendmail_version: 0.2.0
+mhsendmail_binary_url: "https://github.com/mailhog/mhsendmail/releases/download/v{{ mhsendmail_version }}/mhsendmail_linux_amd64"
 
 # Path to daemonize, which is used to launch MailHog via init script.
 mailhog_daemonize_bin_path: /usr/sbin/daemonize


### PR DESCRIPTION
Add support to specify the version of MailHog and mhsendmail using a variable instead of defining the complete mailhog_binary_url to simplify specifying the version to use.

This addresses issue https://github.com/geerlingguy/ansible-role-mailhog/issues/16